### PR TITLE
Improve active term overlap handling utilities

### DIFF
--- a/core/models.py
+++ b/core/models.py
@@ -114,8 +114,6 @@ class UserProfile(models.Model):
 
     def is_member_for_terms(self, terms: Iterable[Term]) -> list[tuple[Term, PurchasedProduct]]:
         terms = list(terms)
-        if len(terms) == 0:
-            raise ValueError("term cannot be an empty list")
 
         purchased_products = PurchasedProduct.objects.filter(
             payment__user=self.user, product__term__in=terms, payment__is_successful=True

--- a/core/models.py
+++ b/core/models.py
@@ -93,7 +93,6 @@ class UserProfile(models.Model):
 
         return [(product.product.term, product) for product in purchased_products]
 
-
     @deprecated("Use is_member_for_terms instead")
     def is_member(self, for_term: Term | None = None) -> tuple[Term, PurchasedProduct | None]:
         """

--- a/core/models.py
+++ b/core/models.py
@@ -110,7 +110,7 @@ class UserProfile(models.Model):
 
         return term, purchased_product.first()
 
-    def is_member_for_terms(self, terms: list[Term] | None = None) -> list[tuple[Term, PurchasedProduct | None]]:
+    def is_member_for_terms(self, terms: list[Term]) -> list[tuple[Term, PurchasedProduct | None]]:
         if len(terms) == 0:
             raise ValueError("term cannot be an empty list")
         

--- a/core/models.py
+++ b/core/models.py
@@ -112,6 +112,9 @@ class UserProfile(models.Model):
         return term, purchased_product.first()
 
     def is_member_for_terms(self, terms: Iterable[Term]) -> list[tuple[Term, PurchasedProduct]]:
+        """
+        Returns a list of (Term, PurchasedProduct) tuples for the given terms where the user is a member. If the user was not a member for any of the given terms, returns an empty list.
+        """
         terms = list(terms)
 
         purchased_products = PurchasedProduct.objects.filter(

--- a/core/models.py
+++ b/core/models.py
@@ -92,7 +92,6 @@ class UserProfile(models.Model):
         return [(product.product.term, product) for product in purchased_products]
 
 
-    @staticmethod
     @deprecated("Use is_member_for_terms instead")
     def is_member(self, for_term: Term | None = None) -> tuple[Term, PurchasedProduct | None]:
         """
@@ -111,7 +110,6 @@ class UserProfile(models.Model):
 
         return term, purchased_product.first()
 
-    @staticmethod
     def is_member_for_terms(self, terms: list[Term] | None = None) -> list[tuple[Term, PurchasedProduct | None]]:
         if len(terms) == 0:
             raise ValueError("term cannot be an empty list")

--- a/core/models.py
+++ b/core/models.py
@@ -1,3 +1,5 @@
+from typing import Iterable
+
 from typing_extensions import deprecated
 from django.db import models
 from django.contrib.auth.models import User
@@ -110,15 +112,36 @@ class UserProfile(models.Model):
 
         return term, purchased_product.first()
 
-    def is_member_for_terms(self, terms: list[Term]) -> list[tuple[Term, PurchasedProduct | None]]:
+    def is_member_for_terms(self, terms: Iterable[Term]) -> list[tuple[Term, PurchasedProduct]]:
+        terms = list(terms)
         if len(terms) == 0:
             raise ValueError("term cannot be an empty list")
-        
+
         purchased_products = PurchasedProduct.objects.filter(
             payment__user=self.user, product__term__in=terms, payment__is_successful=True
         )
 
         return [(product.product.term, product) for product in purchased_products]
+
+    def get_active_membership_terms(self) -> list[tuple[Term, PurchasedProduct]]:
+        """
+        Returns paid memberships for any currently active term.
+
+        Use this to answer "which active memberships does this user have today?"
+        """
+        active_terms = Term.get_active_terms()
+        if not active_terms.exists():
+            return []
+
+        return self.is_member_for_terms(active_terms)
+
+    def is_active_member(self) -> bool:
+        """
+        Returns whether the user has paid dues for any currently active term.
+
+        Use this to answer "is this user a member today?"
+        """
+        return len(self.get_active_membership_terms()) > 0
 
     @staticmethod
     def create_extended_user(net_id, comet_card_serial_number, first, last):

--- a/core/models.py
+++ b/core/models.py
@@ -1,3 +1,4 @@
+from typing_extensions import deprecated
 from django.db import models
 from django.contrib.auth.models import User
 from django.utils.translation import gettext_lazy as _
@@ -90,6 +91,9 @@ class UserProfile(models.Model):
 
         return [(product.product.term, product) for product in purchased_products]
 
+
+    @staticmethod
+    @deprecated("Use is_member_for_terms instead")
     def is_member(self, for_term: Term | None = None) -> tuple[Term, PurchasedProduct | None]:
         """
         Returns a tuple with the Term and PurchasedProduct object for the current member if the user is a member for the given term, or a tuple with the given Term and None if they are not a member.
@@ -106,6 +110,17 @@ class UserProfile(models.Model):
         )
 
         return term, purchased_product.first()
+
+    @staticmethod
+    def is_member_for_terms(self, terms: list[Term] | None = None) -> list[tuple[Term, PurchasedProduct | None]]:
+        if len(terms) == 0:
+            raise ValueError("term cannot be an empty list")
+        
+        purchased_products = PurchasedProduct.objects.filter(
+            payment__user=self.user, product__term__in=terms, payment__is_successful=True
+        )
+
+        return [(product.product.term, product) for product in purchased_products]
 
     @staticmethod
     def create_extended_user(net_id, comet_card_serial_number, first, last):

--- a/core/signals/handlers.py
+++ b/core/signals/handlers.py
@@ -34,7 +34,7 @@ async def update_roles_profile_signal(sender, instance: UserProfile, created, **
     def is_member():
         if not (discord_id := instance.discord_id):
             return False, None
-        return instance.is_member()[1] is not None, discord_id
+        return instance.is_active_member(), discord_id
 
     valid, discord_id = await sync_to_async(is_member)()
     if valid:
@@ -47,7 +47,7 @@ async def update_roles_purchasedproduct_signal(sender, instance: PurchasedProduc
     def is_member():
         if not (discord_id := instance.payment.user.userprofile.discord_id):
             return False, None
-        return instance.payment.user.userprofile.is_member()[1] is not None, discord_id
+        return instance.payment.user.userprofile.is_active_member(), discord_id
 
     valid, discord_id = await sync_to_async(is_member)()
     if valid:

--- a/discord_bot.py
+++ b/discord_bot.py
@@ -360,26 +360,36 @@ async def profile(ctx: discord.ApplicationContext, net_id: str | None, discord_u
         # Membership Status
         def get_membership_status(user_profile: UserProfile):
             today = timezone.now().date()
-            active_memberships = user_profile.get_active_membership_terms()
-            active_term_names = [term.name for term, _ in active_memberships]
+
+            def paid_terms_from(terms):
+                terms = list(terms)
+                paid_term_ids = {term.id for term, _ in user_profile.is_member_for_terms(terms)}
+                return [term for term in terms if term.id in paid_term_ids]
+
+            def term_names(terms):
+                return ", ".join(term.name for term in terms)
+
+            active_terms = Term.get_active_terms().order_by("start_date", "end_date", "name")
+            active_membership_terms = paid_terms_from(active_terms)
             body = "**Current Membership:** " + (
-                "Not a member" if not active_term_names else f"Active for {', '.join(active_term_names)}"
+                "Not a member" if not active_membership_terms else f"Active for {term_names(active_membership_terms)}"
             )
 
             renewal_term = Term.get_active_term_with_latest_end_date()
             has_paid_renewal_term = bool(user_profile.is_member_for_terms([renewal_term])) if renewal_term else False
-            if active_memberships and renewal_term and not has_paid_renewal_term:
-                body += f"\n**Renewal needed:** Pay dues for {renewal_term.name}"
+            if renewal_term and not has_paid_renewal_term:
+                due_status_label = "Renewal needed" if active_membership_terms else "Dues needed"
+                body += f"\n**{due_status_label}:** Pay dues for {renewal_term.name}"
 
-            past_terms = Term.objects.filter(end_date__lt=today)
-            future_terms = Term.objects.filter(start_date__gt=today)
+            past_terms = Term.objects.filter(end_date__lt=today).order_by("-end_date", "-start_date", "name")
+            future_terms = Term.objects.filter(start_date__gt=today).order_by("start_date", "end_date", "name")
 
-            paid_future_terms = [term for term in future_terms if user_profile.is_member_for_terms([term])]
+            paid_future_terms = paid_terms_from(future_terms)
             if len(paid_future_terms) > 0:
-                body += f"\n**Dues paid for future term(s)**: {', '.join([t.name for t in paid_future_terms])}"
+                body += f"\n**Dues paid for future term(s)**: {term_names(paid_future_terms)}"
 
-            paid_past_terms = [term.name for term in past_terms if user_profile.is_member_for_terms([term])]
-            past_terms_info = ", ".join(paid_past_terms) if len(paid_past_terms) > 0 else "No past memberships"
+            paid_past_terms = paid_terms_from(past_terms)
+            past_terms_info = term_names(paid_past_terms) if len(paid_past_terms) > 0 else "No past memberships"
 
             body += f"\n**Past Memberships:** {past_terms_info}"
 

--- a/discord_bot.py
+++ b/discord_bot.py
@@ -365,15 +365,17 @@ async def profile(ctx: discord.ApplicationContext, net_id: str | None, discord_u
                 return ", ".join(sorted(names))
 
             active_terms = Term.get_active_terms().order_by("start_date", "end_date", "name")
-            active_term_names = {term.name for term, _ in user_profile.is_member_for_terms(active_terms)}
+            active_terms_as_member = [term for term, _ in user_profile.is_member_for_terms(active_terms)]
+
+            active_term_names = {term.name for term in active_terms_as_member}
             body = "**Current Membership:** " + (
                 "Not a member" if not active_term_names else f"Active for {term_names(active_term_names)}"
             )
 
             renewal_term = Term.get_active_term_with_latest_end_date()
-            has_paid_renewal_term = bool(user_profile.is_member_for_terms([renewal_term])) if renewal_term else False
+            has_paid_renewal_term = bool(renewal_term in active_terms_as_member) if renewal_term else False
             if renewal_term and not has_paid_renewal_term:
-                due_status_label = "Renewal needed" if active_term_names else "Dues needed"
+                due_status_label = "Renewal needed" if active_terms_as_member else "Dues needed"
                 body += f"\n**{due_status_label}:** Pay dues for {renewal_term.name}"
 
             past_terms = Term.objects.filter(end_date__lt=today).order_by("-end_date", "-start_date", "name")

--- a/discord_bot.py
+++ b/discord_bot.py
@@ -174,7 +174,7 @@ async def respond_user_attendances(interaction: discord.Interaction, user_profil
     await paginator.respond(interaction, ephemeral=True)
 
 
-async def get_current_member_discord_ids():
+async def get_active_member_discord_ids():
     def run() -> list[int]:
         profiles = UserProfile.objects.exclude(discord_id__isnull=True)
         valid_ids: list[int] = []
@@ -636,7 +636,7 @@ async def givememberroles(ctx: discord.ApplicationContext):
 
     message = await ctx.respond("Processing...")
     logger.debug("Starting the role addition...")
-    ids_to_add = await get_current_member_discord_ids()
+    ids_to_add = await get_active_member_discord_ids()
 
     start_time = time.time()
 
@@ -681,7 +681,7 @@ async def purgememberroles(ctx: discord.ApplicationContext):
 
     removed_count = 0
     discord_members = guild.members
-    valid_members = await get_current_member_discord_ids()
+    valid_members = await get_active_member_discord_ids()
 
     start_time = time.time()
     members_to_remove = [member for member in discord_members if member.id not in valid_members]
@@ -727,7 +727,7 @@ async def camera(ctx: discord.ApplicationContext):
     message = await ctx.respond("Processing...", ephemeral=True)
     assert isinstance(message, discord.Interaction)
 
-    valid_members = await get_current_member_discord_ids()
+    valid_members = await get_active_member_discord_ids()
     if ctx.author.id not in valid_members:
         await message.edit_original_response(content=f"You are not registered as a member of {ORG_NAME}!")
     else:

--- a/discord_bot.py
+++ b/discord_bot.py
@@ -176,11 +176,14 @@ async def respond_user_attendances(interaction: discord.Interaction, user_profil
 
 async def get_current_member_discord_ids():
     def run() -> list[int]:
-        current_term = Term.get_current_term()
+        active_terms = Term.get_active_terms()
         profiles = UserProfile.objects.exclude(discord_id__isnull=True)
         valid_ids: list[int] = []
         for profile in profiles:
-            if profile.is_member(current_term)[1]:
+            # TODO: running O(n) queries for each profile is not ideal. we can get this all done with one quicker query...
+            active_terms_as_member = profile.is_member_for_terms(active_terms)
+            is_member_in_active_term = len(active_terms_as_member) > 0
+            if is_member_in_active_term:
                 if profile.discord_id is not None:
                     valid_ids.append(int(profile.discord_id))
         return valid_ids

--- a/discord_bot.py
+++ b/discord_bot.py
@@ -183,11 +183,15 @@ async def get_active_member_discord_ids():
         if len(member_queries) == 0:
             return []
 
-        active_term_purchased_product_query = reduce(lambda x, y: x | y, member_queries).filter(
-            payment__user__userprofile__discord_id__isnull=False
-        ).select_related("payment__user__userprofile")
+        active_term_purchased_product_query = (
+            reduce(lambda x, y: x | y, member_queries)
+            .filter(payment__user__userprofile__discord_id__isnull=False)
+            .select_related("payment__user__userprofile")
+        )
 
-        valid_ids = [int(cast(UserProfile, pp.payment.user.userprofile).discord_id) for pp in active_term_purchased_product_query]
+        valid_ids = [
+            int(cast(UserProfile, pp.payment.user.userprofile).discord_id) for pp in active_term_purchased_product_query
+        ]
 
         return valid_ids
 

--- a/discord_bot.py
+++ b/discord_bot.py
@@ -1,42 +1,44 @@
-import aiohttp
-from asgiref.sync import sync_to_async
 import os
 import time
+from functools import reduce
+from typing import cast
 
+import aiohttp
+from asgiref.sync import sync_to_async
 
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "clubManager.settings")
-from clubManager import settings
-
-import django
 import discord
+import django
 from discord.ext import pages
+
+from clubManager import settings
 
 django.setup()
 
+import asyncio
+import io
+import logging
+import random
+import socket
+import subprocess
+from datetime import datetime
+from datetime import time as dttime
+from operator import itemgetter
+
+import uvicorn
 from django.core.mail import send_mail
+from django.utils import timezone
+from fastapi import FastAPI, Header, HTTPException
 
 from accounts.models import AccountLink
-from core.models import ServerSettings, User, UserProfile
 from common.asyncutils import *
 from common.utils import is_valid_net_id
-from django.utils import timezone
+from core.models import ServerSettings, User, UserProfile
 from events.models import Attendance
 from payments.models import Term
-from datetime import datetime, time as dttime
-import io
-import subprocess
-import socket
-import random
-from operator import itemgetter
-import asyncio
-
-from fastapi import FastAPI, HTTPException, Header
-import uvicorn
-
-import logging
 
 logger = logging.getLogger("discord")
-logger.setLevel(logging.DEBUG if settings.DEBUG else logging.INFO)
+logger.setLevel(logging.DEBUG)
 handler = logging.FileHandler(filename="discord.log", encoding="utf-8", mode="a")
 handler.setFormatter(logging.Formatter("[%(asctime)s] [%(levelname)s] [%(name)s]: %(message)s"))
 logger.addHandler(handler)
@@ -176,13 +178,17 @@ async def respond_user_attendances(interaction: discord.Interaction, user_profil
 
 async def get_active_member_discord_ids():
     def run() -> list[int]:
-        profiles = UserProfile.objects.exclude(discord_id__isnull=True)
-        valid_ids: list[int] = []
-        for profile in profiles:
-            # TODO: running O(n) queries for each profile is not ideal. we can get this all done with one quicker query...
-            if profile.is_active_member():
-                if profile.discord_id is not None:
-                    valid_ids.append(int(profile.discord_id))
+        active_terms = Term.get_active_terms()
+        member_queries = [term.get_members() for term in active_terms]
+        if len(member_queries) == 0:
+            return []
+
+        active_term_purchased_product_query = reduce(lambda x, y: x | y, member_queries).filter(
+            payment__user__userprofile__discord_id__isnull=False
+        ).select_related("payment__user__userprofile")
+
+        valid_ids = [int(cast(UserProfile, pp.payment.user.userprofile).discord_id) for pp in active_term_purchased_product_query]
+
         return valid_ids
 
     return await sync_to_async(run)()

--- a/discord_bot.py
+++ b/discord_bot.py
@@ -366,7 +366,7 @@ async def profile(ctx: discord.ApplicationContext, net_id: str | None, discord_u
                 "Not a member" if not active_term_names else f"Active for {', '.join(active_term_names)}"
             )
 
-            renewal_term = Term.get_active_term_with_latest_start_date()
+            renewal_term = Term.get_active_term_with_latest_end_date()
             has_paid_renewal_term = bool(user_profile.is_member_for_terms([renewal_term])) if renewal_term else False
             if active_memberships and renewal_term and not has_paid_renewal_term:
                 body += f"\n**Renewal needed:** Pay dues for {renewal_term.name}"

--- a/discord_bot.py
+++ b/discord_bot.py
@@ -361,35 +361,32 @@ async def profile(ctx: discord.ApplicationContext, net_id: str | None, discord_u
         def get_membership_status(user_profile: UserProfile):
             today = timezone.now().date()
 
-            def paid_terms_from(terms):
-                terms = list(terms)
-                paid_term_ids = {term.id for term, _ in user_profile.is_member_for_terms(terms)}
-                return [term for term in terms if term.id in paid_term_ids]
-
-            def term_names(terms):
-                return ", ".join(term.name for term in terms)
+            def term_names(names: set[str]):
+                return ", ".join(sorted(names))
 
             active_terms = Term.get_active_terms().order_by("start_date", "end_date", "name")
-            active_membership_terms = paid_terms_from(active_terms)
+            active_term_names = {term.name for term, _ in user_profile.is_member_for_terms(active_terms)}
             body = "**Current Membership:** " + (
-                "Not a member" if not active_membership_terms else f"Active for {term_names(active_membership_terms)}"
+                "Not a member" if not active_term_names else f"Active for {term_names(active_term_names)}"
             )
 
             renewal_term = Term.get_active_term_with_latest_end_date()
             has_paid_renewal_term = bool(user_profile.is_member_for_terms([renewal_term])) if renewal_term else False
             if renewal_term and not has_paid_renewal_term:
-                due_status_label = "Renewal needed" if active_membership_terms else "Dues needed"
+                due_status_label = "Renewal needed" if active_term_names else "Dues needed"
                 body += f"\n**{due_status_label}:** Pay dues for {renewal_term.name}"
 
             past_terms = Term.objects.filter(end_date__lt=today).order_by("-end_date", "-start_date", "name")
             future_terms = Term.objects.filter(start_date__gt=today).order_by("start_date", "end_date", "name")
 
-            paid_future_terms = paid_terms_from(future_terms)
-            if len(paid_future_terms) > 0:
-                body += f"\n**Dues paid for future term(s)**: {term_names(paid_future_terms)}"
+            paid_future_term_names = {term.name for term, _ in user_profile.is_member_for_terms(future_terms)}
+            if len(paid_future_term_names) > 0:
+                body += f"\n**Dues paid for future term(s)**: {term_names(paid_future_term_names)}"
 
-            paid_past_terms = paid_terms_from(past_terms)
-            past_terms_info = term_names(paid_past_terms) if len(paid_past_terms) > 0 else "No past memberships"
+            paid_past_term_names = {term.name for term, _ in user_profile.is_member_for_terms(past_terms)}
+            past_terms_info = (
+                term_names(paid_past_term_names) if len(paid_past_term_names) > 0 else "No past memberships"
+            )
 
             body += f"\n**Past Memberships:** {past_terms_info}"
 

--- a/discord_bot.py
+++ b/discord_bot.py
@@ -552,7 +552,7 @@ async def pay(ctx: discord.ApplicationContext):
             user = UserProfile.objects.get(discord_id=str(ctx.author.id))
         except:
             return None
-        active_terms = Term.objects.filter(end_date__gte=timezone.now())
+        active_terms = Term.get_active_terms()
         if not active_terms:
             # ctx.respond("No active terms available for payment.",  ephemeral=True)  # TODO: move to separate func to await
             pass

--- a/discord_bot.py
+++ b/discord_bot.py
@@ -176,14 +176,11 @@ async def respond_user_attendances(interaction: discord.Interaction, user_profil
 
 async def get_current_member_discord_ids():
     def run() -> list[int]:
-        active_terms = Term.get_active_terms()
         profiles = UserProfile.objects.exclude(discord_id__isnull=True)
         valid_ids: list[int] = []
         for profile in profiles:
             # TODO: running O(n) queries for each profile is not ideal. we can get this all done with one quicker query...
-            active_terms_as_member = profile.is_member_for_terms(active_terms)
-            is_member_in_active_term = len(active_terms_as_member) > 0
-            if is_member_in_active_term:
+            if profile.is_active_member():
                 if profile.discord_id is not None:
                     valid_ids.append(int(profile.discord_id))
         return valid_ids
@@ -352,27 +349,40 @@ async def profile(ctx: discord.ApplicationContext, net_id: str | None, discord_u
 
         # Membership Status
         def get_membership_status(user_profile: UserProfile):
-            current_term, current_payment = user_profile.is_member()
+            today = timezone.now().date()
+            active_memberships = user_profile.get_active_membership_terms()
+            active_term_names = [term.name for term, _ in active_memberships]
             body = "**Current Membership:** " + (
-                "Not a member" if not current_payment else f"Active for {current_term.name}"
+                "Not a member" if not active_term_names else f"Active for {', '.join(active_term_names)}"
             )
 
-            past_terms = Term.objects.filter(end_date__lte=timezone.now())
-            future_terms = Term.objects.filter(start_date__gte=timezone.now()).exclude(pk=current_term.pk)
+            renewal_term = Term.get_active_term_with_latest_start_date()
+            has_paid_renewal_term = bool(user_profile.is_member_for_terms([renewal_term])) if renewal_term else False
+            if active_memberships and renewal_term and not has_paid_renewal_term:
+                body += f"\n**Renewal needed:** Pay dues for {renewal_term.name}"
 
-            paid_future_terms = [term for term in future_terms if user_profile.is_member(term)[1]]
+            past_terms = Term.objects.filter(end_date__lt=today)
+            future_terms = Term.objects.filter(start_date__gt=today)
+
+            paid_future_terms = [term for term in future_terms if user_profile.is_member_for_terms([term])]
             if len(paid_future_terms) > 0:
                 body += f"\n**Dues paid for future term(s)**: {', '.join([t.name for t in paid_future_terms])}"
 
-            paid_past_terms = [term.name for term in past_terms if user_profile.is_member(term)[1]]
+            paid_past_terms = [term.name for term in past_terms if user_profile.is_member_for_terms([term])]
             past_terms_info = ", ".join(paid_past_terms) if len(paid_past_terms) > 0 else "No past memberships"
 
             body += f"\n**Past Memberships:** {past_terms_info}"
 
+            due_paying_url = (
+                f"{settings.PUBLIC_URL}/payments/{renewal_term.product.id}/pay"
+                if renewal_term and not has_paid_renewal_term
+                else None
+            )
+
             return (
                 body,
-                f"{settings.PUBLIC_URL}/payments/{current_term.product.id}/pay" if not current_payment else None,
-                current_term.name,
+                due_paying_url,
+                renewal_term.name if renewal_term else "dues",
             )
 
         membership_status, due_paying_url, term_name = await sync_to_async(get_membership_status)(user_profile)
@@ -550,7 +560,7 @@ async def pay(ctx: discord.ApplicationContext):
         payment_links = [
             (
                 f"[Pay for {term.name}]({settings.PUBLIC_URL}/payments/{term.product.id}/pay/)"
-                + (" (you've already paid this term's dues)" if user.is_member(term)[1] else "")
+                + (" (you've already paid this term's dues)" if user.is_member_for_terms([term]) else "")
             )
             for term in active_terms
         ]
@@ -608,7 +618,7 @@ async def give_member_role(data: dict, authorization: str = Header(None)):
 async def on_member_join(member: discord.Member):
     def is_profile_valid():
         profile = UserProfile.objects.filter(discord_id=str(member.id)).first()
-        return profile and profile.is_member()[1]
+        return profile and profile.is_active_member()
 
     profile_valid = await sync_to_async(is_profile_valid)()
     if profile_valid:

--- a/events/templates/sign_in.html
+++ b/events/templates/sign_in.html
@@ -53,7 +53,6 @@
                     </div>
                 </div>
                 {% elif message == 'nomember' %}
-                <!-- TODO: Here it could be helpful to say which terms the user has paid dues for and which term they haven't. I imagine it could get confusing at the beginning of the spring-fall overlap when people are just getting no-member warnings because it's now possible for them to pay for their fall dues although thats not necessarily something that we make a big announcement of so people might not be aware. We probably honestly just need to refine the condition for that to be a little more sensitive, and generally to be quieter at the beginning of the overlap and louder later when it actually matters, probably like a month to the end of the overlap -->
                 <div class="result-card result-warning">
                     <div class="result-icon">
                         <i data-lucide="alert-triangle"></i>

--- a/events/templates/sign_in.html
+++ b/events/templates/sign_in.html
@@ -53,6 +53,7 @@
                     </div>
                 </div>
                 {% elif message == 'nomember' %}
+                <!-- TODO: Here it could be helpful to say which terms the user has paid dues for and which term they haven't. I imagine it could get confusing at the beginning of the spring-fall overlap when people are just getting no-member warnings because it's now possible for them to pay for their fall dues although thats not necessarily something that we make a big announcement of so people might not be aware. We probably honestly just need to refine the condition for that to be a little more sensitive, and generally to be quieter at the beginning of the overlap and louder later when it actually matters, probably like a month to the end of the overlap -->
                 <div class="result-card result-warning">
                     <div class="result-icon">
                         <i data-lucide="alert-triangle"></i>

--- a/events/views.py
+++ b/events/views.py
@@ -30,7 +30,7 @@ def sign_in(request, event_id):
                 user_profile = UserProfile.objects.get(comet_card_serial_number=student_id)
                 if user_profile:
                     user = user_profile.user
-                    valid_payment = user_profile.is_member()[1]
+                    valid_payment = user_profile.is_active_member()
                     form = SignInForm()
                     status, created = Attendance.objects.get_or_create(event=current_event, user=user)
                     if created:

--- a/get_all_members.py
+++ b/get_all_members.py
@@ -14,6 +14,6 @@ with open("members.csv", "w") as f:
     writer = csv.writer(f)
     writer.writerow(("LastName", "FirstName", "Email"))
     for user in User.objects.all():
-        if not user.userprofile.is_member()[1]:
+        if not user.userprofile.is_active_member():
             continue
         writer.writerow((user.last_name, user.first_name, user.username + "@utdallas.edu"))

--- a/get_all_voters.py
+++ b/get_all_voters.py
@@ -19,7 +19,7 @@ with open("voters.csv", "w") as f:
     writer = csv.writer(f)
     writer.writerow(("FirstName", "LastName", "Email"))
     for user in User.objects.all():
-        if not user.userprofile.is_member()[1]:
+        if not user.userprofile.is_active_member():
             continue
         attendances = Attendance.objects.filter(user=user, event__event_date__gt=ATTENDANCES_SINCE)
         if len(attendances) >= MIN_ATTENDANCES:

--- a/payments/models.py
+++ b/payments/models.py
@@ -67,7 +67,8 @@ class Term(models.Model):
         - current member exports
         - voter eligibility checks before applying attendance requirements
         """
-        return Term.objects.filter(start_date__lte=models.functions.Now(), end_date__gte=models.functions.Now())
+        today = timezone.now().date()
+        return Term.objects.filter(start_date__lte=today, end_date__gte=today)
 
     @staticmethod
     def get_active_term_with_earliest_end_date() -> "Term | None":

--- a/payments/models.py
+++ b/payments/models.py
@@ -50,7 +50,6 @@ class Term(models.Model):
         "Use one of the undeprecated term query utilities (get_active_terms, get_active_term_with_earliest_end_date, get_active_term_with_latest_start_date) which have explicit handling for term overlaps instead"
     )
     def get_current_term() -> "Term | None":
-        # TODO: this needs to return a QuerySet instead of a single object and/or throw if the query returns multiple objects
         return Term.objects.filter(start_date__lte=models.functions.Now(), end_date__gte=models.functions.Now()).first()
 
     @staticmethod
@@ -92,11 +91,7 @@ class Term(models.Model):
         - Do not use this to answer "is this user a member today?" For that, check whether the user has paid for any term returned by `get_active_terms()`.
         - Do not use this to choose which dues product a renewing member should be prompted to buy. For that, use `get_active_term_with_latest_start_date()`.
         """
-        return (
-            Term.objects.filter(start_date__lte=models.functions.Now(), end_date__gte=models.functions.Now())
-            .order_by("end_date")
-            .first()
-        )
+        return Term.get_active_terms().order_by("end_date").first()
 
     @staticmethod
     def get_active_term_with_latest_start_date() -> "Term | None":
@@ -118,11 +113,7 @@ class Term(models.Model):
         Gotchas:
         - Do not use this by itself to answer "is this user a member today?" For that, check whether the user has paid for any term returned by `get_active_terms()`.
         """
-        return (
-            Term.objects.filter(start_date__lte=models.functions.Now(), end_date__gte=models.functions.Now())
-            .order_by("-start_date")
-            .first()
-        )
+        return Term.get_active_terms().order_by("-start_date").first()
 
     def __str__(self):
         return self.name

--- a/payments/models.py
+++ b/payments/models.py
@@ -44,7 +44,7 @@ class Term(models.Model):
     product: Product = models.OneToOneField(Product, on_delete=models.CASCADE)
 
     @staticmethod
-    @deprecated("Use one of the undeprecated term query utilities (need to implement) which have explicit handling for term overlaps instead")
+    @deprecated("Use one of the undeprecated term query utilities (get_active_terms, get_active_term_with_earliest_end_date, get_active_term_with_latest_start_date) which have explicit handling for term overlaps instead")
     def get_current_term() -> "Term" | None:
         # TODO: this needs to return a QuerySet instead of a single object and/or throw if the query returns multiple objects
         return Term.objects.filter(start_date__lte=models.functions.Now(), end_date__gte=models.functions.Now()).first()
@@ -56,6 +56,40 @@ class Term(models.Model):
         Returns a QuerySet of all active terms (terms whose start_date is in the past and end_date is in the future).
         """
         return Term.objects.filter(start_date__lte=models.functions.Now(), end_date__gte=models.functions.Now())
+
+
+    @staticmethod
+    def get_active_term_with_earliest_end_date() -> "Term" | None:
+        """
+        Returns the active term with the earliest end date.
+
+        Example: Given a Spring 2026 term for 2025-12-01 to 2026-08-31, and a Fall 2026 term for 2026-05-01 to 2027-01-31, this function will return different results depending on the current date. 
+
+        - In Spring 2026: returns Spring 2026 term, since that is the only active term.
+        - During Spring 2026 and Fall 2026 overlap period: returns Spring 2026 term. While both Spring 2026 and Fall 2026 terms are active, the Spring 2026 term wins as it has the earliest end date.
+        - In Fall 2026 but after the overlap period: returns Fall 2026 term, since that is the only active term.
+
+        Suggested use-cases:
+        - generating election voting rosters based on the current term
+        - determining if a user needs to pay dues upon event check-in
+        """
+        return Term.objects.filter(start_date__lte=models.functions.Now(), end_date__gte=models.functions.Now()).order_by("end_date").first()
+
+    @staticmethod
+    def get_active_term_with_latest_start_date() -> "Term" | None:
+        """
+        Returns the active term with the latest start date.
+
+        Example: Given a Spring 2026 term for 2025-12-01 to 2026-08-31, and a Fall 2026 term for 2026-05-01 to 2027-01-31, this function will return different results depending on the current date. 
+
+        - In Spring 2026: returns Spring 2026 term, since that is the only active term.
+        - During Spring 2026 and Fall 2026 overlap period: returns Fall 2026 term
+        - In Fall 2026 but after the overlap period: returns Fall 2026 term
+
+        Recommended use-cases:
+        - Selecting a term for member due payment - it is most advantageous to select the term with the latest start date since in theory, this allows the user to remain a member for a longer period of time. If you joined the club in May 2026, why pay dues for the Spring 2026 term when you can pay for the Fall 2026 term and be counted as a member for the remainder of the Spring 2026 term, and the entirety of the Fall 2026 term?
+        """
+        return Term.objects.filter(start_date__lte=models.functions.Now(), end_date__gte=models.functions.Now()).order_by("-start_date").first()
 
     def __str__(self):
         return self.name

--- a/payments/models.py
+++ b/payments/models.py
@@ -42,7 +42,8 @@ class Term(models.Model):
     updated_at = models.DateTimeField(auto_now=True)
     product: Product = models.OneToOneField(Product, on_delete=models.CASCADE)
 
-    def get_current_term():
+    @staticmethod
+    def get_current_term() -> Term | None:
         return Term.objects.filter(start_date__lte=models.functions.Now(), end_date__gte=models.functions.Now()).first()
 
     def __str__(self):

--- a/payments/models.py
+++ b/payments/models.py
@@ -46,11 +46,12 @@ class Term(models.Model):
     product: Product = models.OneToOneField(Product, on_delete=models.CASCADE)
 
     @staticmethod
-    @deprecated("Use one of the undeprecated term query utilities (get_active_terms, get_active_term_with_earliest_end_date, get_active_term_with_latest_start_date) which have explicit handling for term overlaps instead")
-    def get_current_term() -> "Term" | None:
+    @deprecated(
+        "Use one of the undeprecated term query utilities (get_active_terms, get_active_term_with_earliest_end_date, get_active_term_with_latest_start_date) which have explicit handling for term overlaps instead"
+    )
+    def get_current_term() -> "Term | None":
         # TODO: this needs to return a QuerySet instead of a single object and/or throw if the query returns multiple objects
         return Term.objects.filter(start_date__lte=models.functions.Now(), end_date__gte=models.functions.Now()).first()
-
 
     @staticmethod
     def get_active_terms() -> models.QuerySet["Term"]:
@@ -70,15 +71,14 @@ class Term(models.Model):
         """
         return Term.objects.filter(start_date__lte=models.functions.Now(), end_date__gte=models.functions.Now())
 
-
     @staticmethod
-    def get_active_term_with_earliest_end_date() -> "Term" | None:
+    def get_active_term_with_earliest_end_date() -> "Term | None":
         """
         Use this when older-term rules should continue to govern until the older term expires.
 
         Returns the active term with the earliest end date.
 
-        Example: Given a Spring 2026 term for 2025-12-01 to 2026-08-31, and a Fall 2026 term for 2026-05-01 to 2027-01-31, this function will return different results depending on the current date. 
+        Example: Given a Spring 2026 term for 2025-12-01 to 2026-08-31, and a Fall 2026 term for 2026-05-01 to 2027-01-31, this function will return different results depending on the current date.
 
         - In Spring 2026: returns Spring 2026 term, since that is the only active term.
         - During Spring 2026 and Fall 2026 overlap period: returns Spring 2026 term. While both Spring 2026 and Fall 2026 terms are active, the Spring 2026 term wins as it has the earliest end date.
@@ -92,16 +92,20 @@ class Term(models.Model):
         - Do not use this to answer "is this user a member today?" For that, check whether the user has paid for any term returned by `get_active_terms()`.
         - Do not use this to choose which dues product a renewing member should be prompted to buy. For that, use `get_active_term_with_latest_start_date()`.
         """
-        return Term.objects.filter(start_date__lte=models.functions.Now(), end_date__gte=models.functions.Now()).order_by("end_date").first()
+        return (
+            Term.objects.filter(start_date__lte=models.functions.Now(), end_date__gte=models.functions.Now())
+            .order_by("end_date")
+            .first()
+        )
 
     @staticmethod
-    def get_active_term_with_latest_start_date() -> "Term" | None:
+    def get_active_term_with_latest_start_date() -> "Term | None":
         """
         Use this to answer "which active dues term should this user pay for now?"
 
         Returns the active term with the latest start date.
 
-        Example: Given a Spring 2026 term for 2025-12-01 to 2026-08-31, and a Fall 2026 term for 2026-05-01 to 2027-01-31, this function will return different results depending on the current date. 
+        Example: Given a Spring 2026 term for 2025-12-01 to 2026-08-31, and a Fall 2026 term for 2026-05-01 to 2027-01-31, this function will return different results depending on the current date.
 
         - In Spring 2026: returns Spring 2026 term, since that is the only active term.
         - During Spring 2026 and Fall 2026 overlap period: returns Fall 2026 term
@@ -114,7 +118,11 @@ class Term(models.Model):
         Gotchas:
         - Do not use this by itself to answer "is this user a member today?" For that, check whether the user has paid for any term returned by `get_active_terms()`.
         """
-        return Term.objects.filter(start_date__lte=models.functions.Now(), end_date__gte=models.functions.Now()).order_by("-start_date").first()
+        return (
+            Term.objects.filter(start_date__lte=models.functions.Now(), end_date__gte=models.functions.Now())
+            .order_by("-start_date")
+            .first()
+        )
 
     def __str__(self):
         return self.name

--- a/payments/models.py
+++ b/payments/models.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing_extensions import deprecated
 from django.db import models
 from django.contrib.auth.models import User

--- a/payments/models.py
+++ b/payments/models.py
@@ -49,6 +49,14 @@ class Term(models.Model):
         # TODO: this needs to return a QuerySet instead of a single object and/or throw if the query returns multiple objects
         return Term.objects.filter(start_date__lte=models.functions.Now(), end_date__gte=models.functions.Now()).first()
 
+
+    @staticmethod
+    def get_active_terms() -> models.QuerySet["Term"]:
+        """
+        Returns a QuerySet of all active terms (terms whose start_date is in the past and end_date is in the future).
+        """
+        return Term.objects.filter(start_date__lte=models.functions.Now(), end_date__gte=models.functions.Now())
+
     def __str__(self):
         return self.name
 

--- a/payments/models.py
+++ b/payments/models.py
@@ -53,7 +53,18 @@ class Term(models.Model):
     @staticmethod
     def get_active_terms() -> models.QuerySet["Term"]:
         """
+        Use this to answer "is this user a member today?"
+
         Returns a QuerySet of all active terms (terms whose start_date is in the past and end_date is in the future).
+
+        During an overlap period, this returns both the expiring term and the renewing term.
+
+        Suggested use-cases:
+        - determining whether a user is allowed to participate as a current member
+        - Discord member role sync
+        - event check-in membership validity
+        - current member exports
+        - voter eligibility checks before applying attendance requirements
         """
         return Term.objects.filter(start_date__lte=models.functions.Now(), end_date__gte=models.functions.Now())
 
@@ -61,6 +72,8 @@ class Term(models.Model):
     @staticmethod
     def get_active_term_with_earliest_end_date() -> "Term" | None:
         """
+        Use this when older-term rules should continue to govern until the older term expires.
+
         Returns the active term with the earliest end date.
 
         Example: Given a Spring 2026 term for 2025-12-01 to 2026-08-31, and a Fall 2026 term for 2026-05-01 to 2027-01-31, this function will return different results depending on the current date. 
@@ -70,14 +83,20 @@ class Term(models.Model):
         - In Fall 2026 but after the overlap period: returns Fall 2026 term, since that is the only active term.
 
         Suggested use-cases:
-        - generating election voting rosters based on the current term
-        - determining if a user needs to pay dues upon event check-in
+        - generating election voting rosters tied to the expiring academic term, where the renewing term should not replace the older term yet
+        - checking eligibility for processes that intentionally remain attached to the soonest-expiring active term during an overlap period
+
+        Gotchas:
+        - Do not use this to answer "is this user a member today?" For that, check whether the user has paid for any term returned by `get_active_terms()`.
+        - Do not use this to choose which dues product a renewing member should be prompted to buy. For that, use `get_active_term_with_latest_start_date()`.
         """
         return Term.objects.filter(start_date__lte=models.functions.Now(), end_date__gte=models.functions.Now()).order_by("end_date").first()
 
     @staticmethod
     def get_active_term_with_latest_start_date() -> "Term" | None:
         """
+        Use this to answer "which active dues term should this user pay for now?"
+
         Returns the active term with the latest start date.
 
         Example: Given a Spring 2026 term for 2025-12-01 to 2026-08-31, and a Fall 2026 term for 2026-05-01 to 2027-01-31, this function will return different results depending on the current date. 
@@ -88,6 +107,10 @@ class Term(models.Model):
 
         Recommended use-cases:
         - Selecting a term for member due payment - it is most advantageous to select the term with the latest start date since in theory, this allows the user to remain a member for a longer period of time. If you joined the club in May 2026, why pay dues for the Spring 2026 term when you can pay for the Fall 2026 term and be counted as a member for the remainder of the Spring 2026 term, and the entirety of the Fall 2026 term?
+        - membership renewal warnings displayed on event check-ins during an overlap period: a Spring-only member should be warned to pay Fall dues, while a Fall member should not be warned
+
+        Gotchas:
+        - Do not use this by itself to answer "is this user a member today?" For that, check whether the user has paid for any term returned by `get_active_terms()`.
         """
         return Term.objects.filter(start_date__lte=models.functions.Now(), end_date__gte=models.functions.Now()).order_by("-start_date").first()
 

--- a/payments/models.py
+++ b/payments/models.py
@@ -1,3 +1,4 @@
+from typing_extensions import deprecated
 from django.db import models
 from django.contrib.auth.models import User
 from django.core.validators import MaxValueValidator, MinValueValidator
@@ -43,7 +44,9 @@ class Term(models.Model):
     product: Product = models.OneToOneField(Product, on_delete=models.CASCADE)
 
     @staticmethod
+    @deprecated("Use one of the undeprecated term query utilities (need to implement) which have explicit handling for term overlaps instead")
     def get_current_term() -> "Term" | None:
+        # TODO: this needs to return a QuerySet instead of a single object and/or throw if the query returns multiple objects
         return Term.objects.filter(start_date__lte=models.functions.Now(), end_date__gte=models.functions.Now()).first()
 
     def __str__(self):

--- a/payments/models.py
+++ b/payments/models.py
@@ -1,13 +1,12 @@
 from __future__ import annotations
 
-from typing_extensions import deprecated
-from django.db import models
+from computedfields.models import ComputedFieldsModel, computed
 from django.contrib.auth.models import User
 from django.core.validators import MaxValueValidator, MinValueValidator
+from django.db import models
 from django.utils import timezone
 from django.utils.translation import gettext_lazy as _
-
-from computedfields.models import ComputedFieldsModel, computed
+from typing_extensions import deprecated
 
 from common.utils import validate_staff
 
@@ -114,6 +113,15 @@ class Term(models.Model):
         - Do not use this by itself to answer "is this user a member today?" For that, check whether the user has paid for any term returned by `get_active_terms()`.
         """
         return Term.get_active_terms().order_by("-start_date").first()
+
+    def get_members(self):
+        """
+        Returns a QuerySet of all PurchasedProducts for this term with a successful payment associated with this term's Product, allowing you to query all the users with a valid membership for this term.
+        """
+
+        return PurchasedProduct.objects.filter(payment__is_successful=True, product=self.product).select_related(
+            "payment__user"
+        )
 
     def __str__(self):
         return self.name

--- a/payments/models.py
+++ b/payments/models.py
@@ -43,7 +43,7 @@ class Term(models.Model):
     product: Product = models.OneToOneField(Product, on_delete=models.CASCADE)
 
     @staticmethod
-    def get_current_term() -> Term | None:
+    def get_current_term() -> "Term" | None:
         return Term.objects.filter(start_date__lte=models.functions.Now(), end_date__gte=models.functions.Now()).first()
 
     def __str__(self):

--- a/payments/models.py
+++ b/payments/models.py
@@ -46,7 +46,7 @@ class Term(models.Model):
 
     @staticmethod
     @deprecated(
-        "Use one of the undeprecated term query utilities (get_active_terms, get_active_term_with_earliest_end_date, get_active_term_with_latest_start_date) which have explicit handling for term overlaps instead"
+        "Use one of the undeprecated term query utilities (get_active_terms, get_active_term_with_earliest_end_date, get_active_term_with_latest_end_date) which have explicit handling for term overlaps instead.get_active_term_with_latest_end_date"
     )
     def get_current_term() -> "Term | None":
         return Term.objects.filter(start_date__lte=models.functions.Now(), end_date__gte=models.functions.Now()).first()
@@ -88,31 +88,35 @@ class Term(models.Model):
 
         Gotchas:
         - Do not use this to answer "is this user a member today?" For that, check whether the user has paid for any term returned by `get_active_terms()`.
-        - Do not use this to choose which dues product a renewing member should be prompted to buy. For that, use `get_active_term_with_latest_start_date()`.
+        - Do not use this to choose which dues product a renewing member should be prompted to buy. For that, use `get_active_term_with_latest_end_date()`.
         """
         return Term.get_active_terms().order_by("end_date").first()
 
     @staticmethod
-    def get_active_term_with_latest_start_date() -> "Term | None":
+    def get_active_term_with_latest_end_date() -> "Term | None":
         """
         Use this to answer "which active dues term should this user pay for now?"
 
-        Returns the active term with the latest start date.
+        Returns the active term with the latest end date.
+
+        This selects by end date because the goal is to choose the term that keeps the user a member for the longest period of time from today.
 
         Example: Given a Spring 2026 term for 2025-12-01 to 2026-08-31, and a Fall 2026 term for 2026-05-01 to 2027-01-31, this function will return different results depending on the current date.
 
         - In Spring 2026: returns Spring 2026 term, since that is the only active term.
-        - During Spring 2026 and Fall 2026 overlap period: returns Fall 2026 term
-        - In Fall 2026 but after the overlap period: returns Fall 2026 term
+        - During Spring 2026 and Fall 2026 overlap period: returns Fall 2026 term, since it has the latest end date.
+        - In Fall 2026 but after the overlap period: returns Fall 2026 term, since that is the only active term.
 
         Recommended use-cases:
-        - Selecting a term for member due payment - it is most advantageous to select the term with the latest start date since in theory, this allows the user to remain a member for a longer period of time. If you joined the club in May 2026, why pay dues for the Spring 2026 term when you can pay for the Fall 2026 term and be counted as a member for the remainder of the Spring 2026 term, and the entirety of the Fall 2026 term?
+        - Selecting a term for member due payment - it is most advantageous to select the term with the latest end date because this allows the user to remain a member for the longest period of time. If you joined the club in May 2026, why pay dues for the Spring 2026 term when you can pay for the Fall 2026 term and be counted as a member for the remainder of the Spring 2026 term, and the entirety of the Fall 2026 term?
         - membership renewal warnings displayed on event check-ins during an overlap period: a Spring-only member should be warned to pay Fall dues, while a Fall member should not be warned
 
         Gotchas:
         - Do not use this by itself to answer "is this user a member today?" For that, check whether the user has paid for any term returned by `get_active_terms()`.
         """
-        return Term.get_active_terms().order_by("-start_date").first()
+        # sorting by `-start_date` serves as a tie-breaker. in the off chance that two active terms end on the same date, this ensures that we always prefer the "newer" term (by start date) when coverage length is equal.
+        # should be rarely needed but keeps this function deterministic.
+        return Term.get_active_terms().order_by("-end_date", "-start_date").first()
 
     def get_members(self):
         """


### PR DESCRIPTION
This PR updates how the codebase evaluates user membership during overlapping terms, since the codebase previously supported only having one active term at a time. 

I wrote some new utilities allowing each call site to be a bit more explicit about which terms we are evaluating a user for membership for. Since different behavior is desirable for different use cases, we can't evaluate user membership by implicitly assuming which term the call site is wanting to evaluate membership for now that we have multiple active terms at any given point in time. Most of those utilities should all have docstrings that I hope pretty clearly explain their use cases and why they're necessary. If not, please do let me know, because I want those utilities to be clear to other readers. 

After writing those utilities in the model files, I updated the rest of the application to use those new utilities and deprecated the old utilities, which should get removed in a future PR. 

Please start review in:
- `core/models.py`
- `payments/models.py`

Those two files contain the core utility changes and behavior updates. Most of the remaining files are call-site updates to use those utilities.
